### PR TITLE
feat: add new package 'parse-node-args'

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 
 * [vertest](https://github.com/marko-js/utils/blob/master/packages/vertest/README.md) -
   test a package with the versions of dependencies it claims to support
+* [parse-node-args](https://github.com/marko-js/utils/blob/master/packages/parse-node-args/README.md) -
+  extract all valid node flags from a list of process args
 
 ## Contributing
 

--- a/packages/parse-node-args/README.md
+++ b/packages/parse-node-args/README.md
@@ -1,0 +1,29 @@
+# parse-node-args
+
+Utility to extract all valid node flags from a list of process args.
+
+## Install
+
+```bash
+npm install --save parse-node-args
+```
+
+# Usage
+
+**cmd**
+
+```bash
+node ./cli.js --inspect-brk --custom-option
+```
+
+**cli.js**
+
+```javascript
+import { deepEqual } from "assert";
+import pullNodeArgs from "parse-node-args";
+
+const { nodeArgs, cliArgs } = pullNodeArgs(process.argv);
+
+deepEqual(nodeArgs, ["--inspect-brk"]);
+deepEqual(cliArgs, ["--custom-option"]);
+```

--- a/packages/parse-node-args/package.json
+++ b/packages/parse-node-args/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "parse-node-args",
+  "description": "Extract node cli options from a list of flags.",
+  "version": "1.0.0",
+  "author": "Dylan Piercey <dpiercey@ebay.com>",
+  "browser": {
+    "./dist/index.js": "./dist/index.js"
+  },
+  "bugs": "https://github.com/marko-js/utils/issues/new?template=Bug_report.md",
+  "dependencies": {
+    "@babel/runtime": "7.0.0-beta.44"
+  },
+  "files": [
+    "dist"
+  ],
+  "homepage": "https://github.com/marko-js/utils/blob/master/packages/parse-node-args/README.md",
+  "keywords": [
+    "args",
+    "cli",
+    "flags",
+    "node",
+    "parse"
+  ],
+  "license": "MIT",
+  "main": "dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/marko-js/utils/tree/master/packages/parse-node-args"
+  }
+}

--- a/packages/parse-node-args/src/flags.js
+++ b/packages/parse-node-args/src/flags.js
@@ -1,0 +1,46 @@
+export const NODE_FLAGS = new RegExp(
+  [
+    "abort-on-uncaught-exception",
+    "enable-fips",
+    "experimental-modules",
+    "experimental-vm-modules",
+    "force-fips",
+    "icu-data-dir=.+",
+    "inspect-brk(=.+)?",
+    "inspect-port=.+",
+    "inspect(=.+)?",
+    "napi-modules",
+    "no-deprecation",
+    "no-force-async-hooks-checks",
+    "no-warnings",
+    "openssl-config=.+",
+    "pending-deprecation",
+    "preserve-symlinks",
+    "prof-process",
+    "redirect-warnings=.+",
+    "throw-deprecation",
+    "tls-cipher-list=.+",
+    "trace-deprecation",
+    "trace-event-categories",
+    "trace-event-file-pattern",
+    "trace-events-enabled",
+    "trace-sync-io",
+    "trace-warnings",
+    "track-heap-objects",
+    "use-bundled-ca",
+    "use-openssl-ca",
+    "v8-options",
+    "v8-pool-size=.+",
+    "zero-fill-buffers",
+    "harmony.*",
+    ["r .+", "require .+"]
+  ]
+    .map(flag => {
+      if (Array.isArray(flag)) {
+        return `-${flag[0]}|--${flag[1]}`;
+      }
+
+      return `--${flag}`;
+    })
+    .join("|")
+);

--- a/packages/parse-node-args/src/index.js
+++ b/packages/parse-node-args/src/index.js
@@ -1,0 +1,28 @@
+import { NODE_FLAGS } from "./flags";
+
+/**
+ * @description
+ * Extracts out nodejs flags from a list of arguments.
+ *
+ * @param {string[]} args The arguments list to look through (usually process.argv.slice(2) for cli's).
+ */
+function parse(args) {
+  const cliArgs = [];
+  const nodeArgs = [];
+
+  for (const arg of args) {
+    if (NODE_FLAGS.test(arg)) {
+      nodeArgs.push(arg);
+    } else {
+      cliArgs.push(arg);
+    }
+  }
+
+  return {
+    cliArgs,
+    nodeArgs
+  };
+}
+
+module.exports = exports = parse;
+export default parse;

--- a/packages/parse-node-args/test/main.test.js
+++ b/packages/parse-node-args/test/main.test.js
@@ -1,0 +1,57 @@
+import * as assert from "assert";
+import parse from "../src";
+
+describe("parse-node-args", () => {
+  it("should extract supported node flags", () => {
+    const nodeArgs = [
+      "--abort-on-uncaught-exception",
+      "--enable-fips",
+      "--experimental-modules",
+      "--experimental-vm-modules",
+      "--force-fips",
+      "--icu-data-dir=./test",
+      "--inspect-brk",
+      "--inspect-port=3000",
+      "--napi-modules",
+      "--no-deprecation",
+      "--no-force-async-hooks-checks",
+      "--no-warnings",
+      "--openssl-config=./test.config",
+      "--pending-deprecation",
+      "--preserve-symlinks",
+      "--prof-process",
+      "--redirect-warnings=./test.logs",
+      "--throw-deprecation",
+      "--tls-cipher-list=./test/list",
+      "--trace-deprecation",
+      "--trace-event-categories",
+      "--trace-event-file-pattern",
+      "--trace-events-enabled",
+      "--trace-sync-io",
+      "--trace-warnings",
+      "--track-heap-objects",
+      "--use-bundled-ca",
+      "--use-openssl-ca",
+      "--v8-options",
+      "--v8-pool-size=1",
+      "--zero-fill-buffers",
+      "--harmony-modules",
+      "--require thing",
+      "-r other-thing"
+    ];
+
+    const cliArgs = ["something", "--other"];
+
+    assert.deepEqual(parse(nodeArgs.concat(cliArgs)), {
+      cliArgs,
+      nodeArgs
+    });
+  });
+
+  it("should not care about order", () => {
+    assert.deepEqual(parse(["./cli.js", "--my-option", "--inspect-brk"]), {
+      cliArgs: ["./cli.js", "--my-option"],
+      nodeArgs: ["--inspect-brk"]
+    });
+  });
+});


### PR DESCRIPTION
## Description

This pr adds a new package which can extract node flags from a list of arguments.

## Motivation and Context

This utility will be used my `marko-cli` to pass along node args to the child process.

## Checklist:

* [x] I have updated/added documentation affected by my changes.
* [x] I have added tests to cover my changes.
