### PR TITLE
fix(vertest): verbose progress option

### DIFF
--- a/packages/vertest/src/run.js
+++ b/packages/vertest/src/run.js
@@ -74,7 +74,11 @@ export default async options => {
             workers.push(worker);
           })
       })),
-      { concurrent: options.concurrency, exitOnError: false }
+      {
+        renderer: options.progress,
+        concurrent: options.concurrency,
+        exitOnError: false
+      }
     ).run();
   } catch (e) {
     testsFailed = true;


### PR DESCRIPTION
## Description

Makes the progress rendering flag work for vertest.

## Motivation and Context

This looked awful in the CI.

## Checklist:

* [ ] I have updated/added documentation affected by my changes.
* [ ] I have added tests to cover my changes.